### PR TITLE
Add initial Rust SDK crate with async client, receipt verifier, and storage

### DIFF
--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "alure-sdk"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+base64 = "0.21"
+chrono = { version = "0.4", features = ["clock", "serde"] }
+dirs = "5"
+ed25519-dalek = { version = "2", features = ["pkcs8"] }
+hostname = "0.3"
+mac_address = "1"
+pkcs8 = { version = "0.10", features = ["pem"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "1"
+tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread", "time"] }
+urlencoding = "2"
+uuid = { version = "1", features = ["v5"] }
+whoami = "1"

--- a/sdk-rust/README.md
+++ b/sdk-rust/README.md
@@ -1,13 +1,75 @@
 # SDK Rust
 
-Obiettivo: crate async per licensing + update.
+SDK async per licensing + update, ispirato allo SDK Python.
 
-Funzionalita principali:
+## Funzionalita principali
 - Attivazione licenza online
 - Validazione offline tramite receipt
 - Check update e download asset
 - Storage locale configurabile
 
-Prossimi passi:
-- Definire client async con reqwest
-- Implementare verify receipt
+## Installazione (dev)
+```bash
+cargo add alure-sdk
+```
+
+## Uso rapido
+```rust
+use alure_sdk::AlureClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = AlureClient::new(
+        Some("http://localhost:3000/api/v1".to_string()),
+        None,
+        None,
+        None,
+    )?;
+
+    // Activate license
+    let activation = client
+        .activate("ALR-XXXXXX-YYYYYY-ZZZZZZ", Some("device-123".to_string()), None, None)
+        .await?;
+    println!("Activation: {}", activation.activation_id);
+
+    // Verify online
+    let result = client.verify_online(None, None).await?;
+    println!("Verify online: {result:?}");
+
+    // Verify offline (use server public key for signature check)
+    let offline = client.verify_offline(None, None, false)?;
+    println!("Verify offline: {} {:?}", offline.valid, offline.reason);
+
+    // Check update
+    let latest = client
+        .check_update("demo", "stable", None)
+        .await?;
+    println!("Latest version: {latest:?}");
+
+    // Download asset (token protected)
+    if let Some(asset_id) = latest
+        .get("asset")
+        .and_then(|asset| asset.get("asset_id"))
+        .and_then(|value| value.as_str())
+    {
+        let file_path = client.download_asset(asset_id, None, None, None, None).await?;
+        println!("Downloaded: {}", file_path.display());
+    }
+
+    Ok(())
+}
+```
+
+## Receipt signature (opzionale)
+Per la verifica offline con firma, passa la chiave pubblica Ed25519:
+```rust
+use alure_sdk::AlureClient;
+
+let client = AlureClient::new(
+    None,
+    None,
+    Some("-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----".to_string()),
+    None,
+)?;
+let offline = client.verify_offline(None, None, true)?;
+```

--- a/sdk-rust/src/client.rs
+++ b/sdk-rust/src/client.rs
@@ -1,0 +1,372 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::errors::{AlureError, ReceiptError, StorageError};
+use crate::receipt::{ReceiptValidationResult, ReceiptVerifier};
+use crate::storage::{FileStorage, ReceiptRecord};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivateResponse {
+    pub receipt: String,
+    pub activation_id: String,
+    pub expires_at: Option<String>,
+    pub grace_period_days: i64,
+    pub server_time: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AlureClient {
+    base_url: String,
+    storage: FileStorage,
+    verifier: ReceiptVerifier,
+    timeout_seconds: u64,
+}
+
+impl AlureClient {
+    pub fn new(
+        base_url: Option<String>,
+        storage_dir: Option<PathBuf>,
+        public_key_pem: Option<String>,
+        timeout_seconds: Option<u64>,
+    ) -> Result<Self, AlureError> {
+        let base_url = base_url.unwrap_or_else(|| "http://localhost:3000/api/v1".to_string());
+        let storage = FileStorage::new(storage_dir).map_err(AlureError::Storage)?;
+        let verifier = ReceiptVerifier::new(public_key_pem);
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            storage,
+            verifier,
+            timeout_seconds: timeout_seconds.unwrap_or(10),
+        })
+    }
+
+    pub fn default_device_id(&self) -> Result<String, AlureError> {
+        let host = hostname::get()
+            .map_err(|err| StorageError(format!("hostname_failed: {err}")))?
+            .to_string_lossy()
+            .to_string();
+        let mac = mac_address::get_mac_address()
+            .map_err(|err| StorageError(format!("mac_address_failed: {err}")))?
+            .map(|addr| addr.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        let user = whoami::username();
+        let raw = format!("{host}-{mac}-{user}");
+        Ok(uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_DNS, raw.as_bytes()).to_string())
+    }
+
+    async fn request<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        json_body: Option<serde_json::Value>,
+        query: Option<Vec<(String, String)>>,
+        headers: Option<Vec<(String, String)>>,
+    ) -> Result<T, AlureError> {
+        let url = format!("{}{}", self.base_url, path);
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(self.timeout_seconds))
+            .build()?;
+        let mut req = client.request(method, &url).header("Accept", "application/json");
+        if let Some(body) = json_body {
+            req = req.json(&body);
+        }
+        if let Some(params) = query {
+            req = req.query(&params);
+        }
+        if let Some(items) = headers {
+            for (key, value) in items {
+                req = req.header(&key, &value);
+            }
+        }
+        let resp = req.send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(AlureError::Http {
+                status: status.as_u16(),
+                message,
+            });
+        }
+        if status == reqwest::StatusCode::NO_CONTENT {
+            let empty = serde_json::json!({});
+            return Ok(serde_json::from_value(empty)?);
+        }
+        let payload = resp.json::<T>().await?;
+        Ok(payload)
+    }
+
+    pub async fn activate(
+        &self,
+        license_key: &str,
+        device_id: Option<String>,
+        app_version: Option<String>,
+        device_meta: Option<serde_json::Value>,
+    ) -> Result<ActivateResponse, AlureError> {
+        let device_id = match device_id {
+            Some(value) => value,
+            None => self.default_device_id()?,
+        };
+        let mut payload = serde_json::json!({
+            "license_key": license_key,
+            "device_id": device_id,
+        });
+        if let Some(app_version) = app_version {
+            payload["app_version"] = serde_json::Value::String(app_version);
+        }
+        if let Some(meta) = device_meta {
+            payload["device_meta"] = meta;
+        }
+        let data: serde_json::Value = self
+            .request(
+                reqwest::Method::POST,
+                "/licenses/activate",
+                Some(payload),
+                None,
+                None,
+            )
+            .await?;
+        let receipt = data
+            .get("receipt")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let activation_id = data
+            .get("activation_id")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let expires_at = data
+            .get("expires_at")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        let grace_period_days = data
+            .get("grace_period_days")
+            .and_then(|value| value.as_i64())
+            .unwrap_or(0);
+        let server_time = data
+            .get("server_time")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let record = ReceiptRecord {
+            receipt: receipt.clone(),
+            device_id: device_id.clone(),
+            activation_id: Some(activation_id.clone()),
+            project_id: self.extract_project_id(&receipt).ok().flatten(),
+        };
+        self.storage.save_receipt(&record)?;
+        Ok(ActivateResponse {
+            receipt,
+            activation_id,
+            expires_at,
+            grace_period_days,
+            server_time,
+        })
+    }
+
+    pub async fn verify_online(
+        &self,
+        receipt: Option<String>,
+        device_id: Option<String>,
+    ) -> Result<serde_json::Value, AlureError> {
+        let (receipt, device_id) = match (receipt, device_id) {
+            (Some(receipt), Some(device_id)) => (receipt, device_id),
+            _ => {
+                let stored = self
+                    .storage
+                    .load_receipt()?
+                    .ok_or_else(|| AlureError::Http {
+                        status: 400,
+                        message: "missing_receipt".to_string(),
+                    })?;
+                (stored.receipt, stored.device_id)
+            }
+        };
+        let payload = serde_json::json!({
+            "receipt": receipt,
+            "device_id": device_id,
+        });
+        self.request(
+            reqwest::Method::POST,
+            "/licenses/verify",
+            Some(payload),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub fn verify_offline(
+        &self,
+        receipt: Option<String>,
+        device_id: Option<String>,
+        verify_signature: bool,
+    ) -> Result<ReceiptValidationResult, AlureError> {
+        let (receipt, device_id) = match (receipt, device_id) {
+            (Some(receipt), Some(device_id)) => (receipt, device_id),
+            _ => {
+                let stored = self.storage.load_receipt()?;
+                if let Some(stored) = stored {
+                    (stored.receipt, stored.device_id)
+                } else {
+                    return Ok(ReceiptValidationResult {
+                        valid: false,
+                        reason: Some("missing_receipt".to_string()),
+                        expires_at: None,
+                        grace_period_days: None,
+                    });
+                }
+            }
+        };
+        Ok(self
+            .verifier
+            .validate_offline(&receipt, &device_id, None, verify_signature))
+    }
+
+    pub async fn check_update(
+        &self,
+        project_id: &str,
+        channel: &str,
+        current_version: Option<String>,
+    ) -> Result<serde_json::Value, AlureError> {
+        let mut query = vec![
+            ("project_id".to_string(), project_id.to_string()),
+            ("channel".to_string(), channel.to_string()),
+        ];
+        if let Some(current_version) = current_version {
+            query.push(("current_version".to_string(), current_version));
+        }
+        self.request(
+            reqwest::Method::GET,
+            "/updates/latest",
+            None,
+            Some(query),
+            None,
+        )
+        .await
+    }
+
+    pub fn project_id_from_receipt(&self, receipt: Option<String>) -> Result<Option<String>, AlureError> {
+        let receipt = match receipt {
+            Some(receipt) => receipt,
+            None => {
+                let stored = self.storage.load_receipt()?;
+                if let Some(stored) = stored {
+                    stored.receipt
+                } else {
+                    return Ok(None);
+                }
+            }
+        };
+        Ok(self.extract_project_id(&receipt).ok().flatten())
+    }
+
+    pub async fn request_download_token(
+        &self,
+        receipt: &str,
+        device_id: &str,
+        asset_id: &str,
+    ) -> Result<serde_json::Value, AlureError> {
+        let payload = serde_json::json!({
+            "receipt": receipt,
+            "device_id": device_id,
+            "asset_id": asset_id,
+        });
+        self.request(
+            reqwest::Method::POST,
+            "/updates/download-token",
+            Some(payload),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn download_asset(
+        &self,
+        asset_id: &str,
+        receipt: Option<String>,
+        device_id: Option<String>,
+        token: Option<String>,
+        dest_path: Option<PathBuf>,
+    ) -> Result<PathBuf, AlureError> {
+        let token = match token {
+            Some(token) => token,
+            None => {
+                let (receipt, device_id) = match (receipt, device_id) {
+                    (Some(receipt), Some(device_id)) => (receipt, device_id),
+                    _ => {
+                        let stored = self
+                            .storage
+                            .load_receipt()?
+                            .ok_or_else(|| AlureError::Http {
+                                status: 400,
+                                message: "missing_receipt".to_string(),
+                            })?;
+                        (stored.receipt, stored.device_id)
+                    }
+                };
+                let token_resp = self
+                    .request_download_token(&receipt, &device_id, asset_id)
+                    .await?;
+                token_resp
+                    .get("token")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default()
+                    .to_string()
+            }
+        };
+
+        let url = format!(
+            "{}/updates/download/{}?token={}",
+            self.base_url,
+            asset_id,
+            urlencoding::encode(&token)
+        );
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(self.timeout_seconds))
+            .build()?;
+        let resp = client.get(url).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(AlureError::Http {
+                status: status.as_u16(),
+                message,
+            });
+        }
+        let content = resp.bytes().await?;
+        let filename = resp
+            .headers()
+            .get(reqwest::header::CONTENT_DISPOSITION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(extract_filename)
+            .unwrap_or_else(|| format!("{asset_id}.bin"));
+        let target = match dest_path {
+            Some(path) => path,
+            None => {
+                let downloads = self.storage.downloads_dir()?;
+                downloads.join(filename)
+            }
+        };
+        tokio::fs::write(&target, &content).await?;
+        Ok(target)
+    }
+
+    fn extract_project_id(&self, receipt: &str) -> Result<Option<String>, ReceiptError> {
+        let payload = self.verifier.parse(receipt)?;
+        Ok(payload
+            .get("project_id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string))
+    }
+}
+
+fn extract_filename(content_disposition: &str) -> Option<String> {
+    let filename_marker = "filename=";
+    content_disposition.find(filename_marker).map(|idx| {
+        content_disposition[idx + filename_marker.len()..]
+            .trim_matches('"')
+            .to_string()
+    })
+}

--- a/sdk-rust/src/errors.rs
+++ b/sdk-rust/src/errors.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AlureError {
+    #[error("http {status}: {message}")]
+    Http { status: u16, message: String },
+    #[error("request failed: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("storage error: {0}")]
+    Storage(#[from] StorageError),
+    #[error("receipt error: {0}")]
+    Receipt(#[from] ReceiptError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Error)]
+#[error("http {status}: {message}")]
+pub struct HttpError {
+    pub status: u16,
+    pub message: String,
+}
+
+#[derive(Debug, Error)]
+#[error("receipt error: {0}")]
+pub struct ReceiptError(pub String);
+
+#[derive(Debug, Error)]
+#[error("storage error: {0}")]
+pub struct StorageError(pub String);

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -1,0 +1,9 @@
+mod client;
+mod errors;
+mod receipt;
+mod storage;
+
+pub use client::{ActivateResponse, AlureClient};
+pub use errors::{AlureError, HttpError, ReceiptError, StorageError};
+pub use receipt::{ReceiptValidationResult, ReceiptVerifier};
+pub use storage::{FileStorage, ReceiptRecord};

--- a/sdk-rust/src/receipt.rs
+++ b/sdk-rust/src/receipt.rs
@@ -1,0 +1,155 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use chrono::{DateTime, Duration, Utc};
+use ed25519_dalek::{Signature, VerifyingKey};
+use pkcs8::DecodePublicKey;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::errors::ReceiptError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceiptValidationResult {
+    pub valid: bool,
+    pub reason: Option<String>,
+    pub expires_at: Option<String>,
+    pub grace_period_days: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReceiptVerifier {
+    public_key_pem: Option<String>,
+}
+
+impl ReceiptVerifier {
+    pub fn new(public_key_pem: Option<String>) -> Self {
+        Self { public_key_pem }
+    }
+
+    pub fn parse(&self, token: &str) -> Result<serde_json::Value, ReceiptError> {
+        let parts: Vec<&str> = token.split('.').collect();
+        if parts.len() != 3 || parts[0] != "v1" {
+            return Err(ReceiptError("invalid_receipt_format".to_string()));
+        }
+        let payload_bytes = URL_SAFE_NO_PAD
+            .decode(parts[1])
+            .map_err(|_| ReceiptError("invalid_receipt_payload".to_string()))?;
+        let payload = serde_json::from_slice(&payload_bytes)
+            .map_err(|_| ReceiptError("invalid_receipt_payload".to_string()))?;
+        Ok(payload)
+    }
+
+    pub fn verify_signature(&self, token: &str) -> Result<bool, ReceiptError> {
+        let public_key_pem = self
+            .public_key_pem
+            .as_ref()
+            .ok_or_else(|| ReceiptError("public_key_required".to_string()))?;
+        let parts: Vec<&str> = token.split('.').collect();
+        if parts.len() != 3 || parts[0] != "v1" {
+            return Ok(false);
+        }
+        let payload = parts[1].as_bytes();
+        let signature_bytes = URL_SAFE_NO_PAD
+            .decode(parts[2])
+            .map_err(|_| ReceiptError("invalid_signature".to_string()))?;
+        let signature = Signature::from_slice(&signature_bytes)
+            .map_err(|_| ReceiptError("invalid_signature".to_string()))?;
+        let verifying_key = VerifyingKey::from_public_key_pem(public_key_pem)
+            .map_err(|_| ReceiptError("invalid_public_key".to_string()))?;
+        Ok(verifying_key.verify(payload, &signature).is_ok())
+    }
+
+    pub fn validate_offline(
+        &self,
+        token: &str,
+        device_id: &str,
+        now: Option<DateTime<Utc>>,
+        verify_signature: bool,
+    ) -> ReceiptValidationResult {
+        let payload = match self.parse(token) {
+            Ok(payload) => payload,
+            Err(err) => {
+                return ReceiptValidationResult {
+                    valid: false,
+                    reason: Some(err.0),
+                    expires_at: None,
+                    grace_period_days: None,
+                }
+            }
+        };
+        if verify_signature {
+            match self.verify_signature(token) {
+                Ok(true) => {}
+                Ok(false) => {
+                    return ReceiptValidationResult {
+                        valid: false,
+                        reason: Some("invalid_signature".to_string()),
+                        expires_at: None,
+                        grace_period_days: None,
+                    }
+                }
+                Err(err) => {
+                    return ReceiptValidationResult {
+                        valid: false,
+                        reason: Some(err.0),
+                        expires_at: None,
+                        grace_period_days: None,
+                    }
+                }
+            }
+        }
+
+        let device_hash = Sha256::digest(device_id.as_bytes());
+        let device_hash_hex = format!("{:x}", device_hash);
+        if payload
+            .get("device_id_hash")
+            .and_then(|value| value.as_str())
+            != Some(device_hash_hex.as_str())
+        {
+            return ReceiptValidationResult {
+                valid: false,
+                reason: Some("device_mismatch".to_string()),
+                expires_at: None,
+                grace_period_days: None,
+            };
+        }
+
+        let expires_at = payload
+            .get("expires_at")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        let grace_days = payload
+            .get("grace_period_days")
+            .and_then(|value| value.as_i64())
+            .unwrap_or(0);
+        let now_dt = now.unwrap_or_else(Utc::now);
+        if let Some(expires_at_str) = expires_at.clone() {
+            if let Ok(exp_dt) = DateTime::parse_from_rfc3339(&expires_at_str) {
+                let exp_dt = exp_dt.with_timezone(&Utc);
+                if now_dt > exp_dt {
+                    let grace_limit = exp_dt + Duration::days(grace_days);
+                    if now_dt > grace_limit {
+                        return ReceiptValidationResult {
+                            valid: false,
+                            reason: Some("expired".to_string()),
+                            expires_at: Some(expires_at_str),
+                            grace_period_days: Some(grace_days),
+                        };
+                    }
+                    return ReceiptValidationResult {
+                        valid: true,
+                        reason: Some("grace_period".to_string()),
+                        expires_at: Some(expires_at_str),
+                        grace_period_days: Some(grace_days),
+                    };
+                }
+            }
+        }
+
+        ReceiptValidationResult {
+            valid: true,
+            reason: None,
+            expires_at,
+            grace_period_days: Some(grace_days),
+        }
+    }
+}

--- a/sdk-rust/src/storage.rs
+++ b/sdk-rust/src/storage.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use crate::errors::StorageError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceiptRecord {
+    pub receipt: String,
+    pub device_id: String,
+    pub activation_id: Option<String>,
+    pub project_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FileStorage {
+    base_dir: PathBuf,
+    receipt_path: PathBuf,
+}
+
+impl FileStorage {
+    pub fn new(base_dir: Option<PathBuf>) -> Result<Self, StorageError> {
+        let dir = match base_dir {
+            Some(path) => path,
+            None => dirs::home_dir()
+                .ok_or_else(|| StorageError("missing_home_dir".to_string()))?
+                .join(".alure"),
+        };
+        std::fs::create_dir_all(&dir)
+            .map_err(|err| StorageError(format!("create_dir_failed: {err}")))?;
+        let receipt_path = dir.join("receipt.json");
+        Ok(Self {
+            base_dir: dir,
+            receipt_path,
+        })
+    }
+
+    pub fn save_receipt(&self, record: &ReceiptRecord) -> Result<(), StorageError> {
+        let payload = serde_json::json!({
+            "receipt": record.receipt,
+            "device_id": record.device_id,
+            "activation_id": record.activation_id,
+            "project_id": record.project_id,
+        });
+        let content = serde_json::to_string_pretty(&payload)
+            .map_err(|err| StorageError(format!("serialize_failed: {err}")))?;
+        std::fs::write(&self.receipt_path, content)
+            .map_err(|err| StorageError(format!("write_failed: {err}")))?;
+        Ok(())
+    }
+
+    pub fn load_receipt(&self) -> Result<Option<ReceiptRecord>, StorageError> {
+        if !self.receipt_path.exists() {
+            return Ok(None);
+        }
+        let content = std::fs::read_to_string(&self.receipt_path)
+            .map_err(|err| StorageError(format!("read_failed: {err}")))?;
+        let payload: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|err| StorageError(format!("parse_failed: {err}")))?;
+        Ok(Some(ReceiptRecord {
+            receipt: payload
+                .get("receipt")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            device_id: payload
+                .get("device_id")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            activation_id: payload
+                .get("activation_id")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+            project_id: payload
+                .get("project_id")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+        }))
+    }
+
+    pub fn receipts_path(&self) -> &Path {
+        &self.receipt_path
+    }
+
+    pub fn downloads_dir(&self) -> Result<PathBuf, StorageError> {
+        let downloads = self.base_dir.join("downloads");
+        std::fs::create_dir_all(&downloads)
+            .map_err(|err| StorageError(format!("create_dir_failed: {err}")))?;
+        Ok(downloads)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a Rust version of the existing Python SDK to offer licensing, update checks and asset downloads for async Rust apps. 
- Support offline receipt validation and local persistence similar to the Python SDK. 
- Offer an ergonomic async client using `reqwest` and a pluggable storage layer for desktop/server use. 

### Description
- Add a new `sdk-rust` crate with `Cargo.toml` listing dependencies such as `reqwest`, `tokio`, `ed25519-dalek`, `sha2`, and `uuid`. 
- Implement an async `AlureClient` in `sdk-rust/src/client.rs` providing `activate`, `verify_online`, `verify_offline`, `check_update`, `request_download_token`, and `download_asset` methods. 
- Add receipt parsing and offline verification logic in `sdk-rust/src/receipt.rs` and file-based storage helpers in `sdk-rust/src/storage.rs`. 
- Introduce error types in `sdk-rust/src/errors.rs` and re-export the public API in `sdk-rust/src/lib.rs`, and document usage in `sdk-rust/README.md`. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683b7af1d4832c83163543b8dc73e6)