### PR TITLE
Add PyPI metadata and publishing guidance for Python SDK

### DIFF
--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -14,6 +14,23 @@ Funzionalita principali:
 pip install -e .
 ```
 
+## Installazione (PyPI)
+```
+pip install alure-sdk
+```
+
+## Pubblicazione su PyPI
+Prerequisiti:
+- Accesso a PyPI (account: `tarantola23`).
+- Token API PyPI salvato in ambiente (`TWINE_USERNAME=__token__`, `TWINE_PASSWORD=<token>`).
+
+Build e upload:
+```
+python -m pip install --upgrade build twine
+python -m build
+python -m twine upload dist/*
+```
+
 ## Uso rapido
 ```python
 from alure_sdk import AlureClient

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -10,6 +10,20 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Alure" }]
+keywords = ["licensing", "updates", "sdk", "alure"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.urls]
+Homepage = "https://github.com/alure-ai/alure"
+Repository = "https://github.com/alure-ai/alure"
+Issues = "https://github.com/alure-ai/alure/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
### Motivation
- Prepare the Python SDK for publishing by adding package metadata to improve discoverability and signal supported Python versions. 
- Provide clear PyPI installation and release instructions in the SDK README including the PyPI account (`tarantola23`) and Twine token environment variables to streamline releases.

### Description
- Updated `sdk-python/pyproject.toml` to add `keywords`, `classifiers` for Python `3.10`–`3.13`, and a `project.urls` block (`Homepage`, `Repository`, `Issues`).
- Updated `sdk-python/README.md` to add a `Installazione (PyPI)` section and a `Pubblicazione su PyPI` section documenting account details, Twine environment variables, and build/upload commands (`python -m build`, `python -m twine upload dist/*`).
- No functional code changes were made; all edits are documentation and package metadata only.

### Testing
- No automated tests were run because the changes are limited to documentation and package metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694efef6b0832cbd2ed8d5a5045134)